### PR TITLE
add import comment to avoid aliasing and be clear about the import path

### DIFF
--- a/socks.go
+++ b/socks.go
@@ -9,7 +9,7 @@ A complete example using this package:
 	package main
 
 	import (
-		"h12.me/socks"
+		"h12.me/socks" // import "h12.me/socks"
 		"fmt"
 		"net/http"
 		"io/ioutil"


### PR DESCRIPTION
import comment as described in https://golang.org/s/go14customimport

This would be consistent with README.md https://github.com/hailiang/socks#import-the-package  declaring that the import path is "h12.me/socks" (and not "github.com/hailiang/socks").  The change will help to avoid confusion regarding under which import path the package should be included and potentially the package being linked under two different import paths (through transitive dependencies, etc.)

This will break builds of clients still using "github.com/hailiang/socks" but on the other hand will inform them about the canonical import path for the package.