### PR TITLE
Package import comment and minor README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ SOCKS is a SOCKS4, SOCKS4A and SOCKS5 proxy package for Go.
     httpClient := &http.Client{Transport: tr}
 
 ## Alternatives
-http://code.google.com/p/go/source/browse/?repo=net#hg%2Fproxy
+http://godoc.org/golang.org/x/net/proxy

--- a/socks.go
+++ b/socks.go
@@ -38,7 +38,7 @@ A complete example using this package:
 		return
 	}
 */
-package socks
+package socks // import "h12.me/socks"
 
 import (
 	"errors"


### PR DESCRIPTION
replaces the buggy https://github.com/hailiang/socks/pull/3

import "magic" comment goes next to the package declaration:
package socks // import "h12.me/socks"